### PR TITLE
Reference set name via set rather than set_name

### DIFF
--- a/java/src/main/java/com/aerospike/helper/model/Set.java
+++ b/java/src/main/java/com/aerospike/helper/model/Set.java
@@ -72,7 +72,7 @@ public class Set {
 					storedValue.value = value;
 				}
 			}
-			this.name = (String) values.get("set_name").value;
+			this.name = (String) values.get("set").value;
 		}
 	}
 


### PR DESCRIPTION
It seems that at least with version 3.9.0 of aerospike that the set name is referenced by they key "set" rather than set_name. For me this fixes the unit tests on aerospark.