### PR TITLE
Use slf4j-api for logging instead of log4j 1.x

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -102,6 +102,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>[1.7.25,)</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>

--- a/java/src/main/java/com/aerospike/helper/model/Module.java
+++ b/java/src/main/java/com/aerospike/helper/model/Module.java
@@ -1,6 +1,8 @@
 package com.aerospike.helper.model;
 
 import gnu.crypto.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -11,8 +13,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
-
 /**
  * This class represents a UDF module
  * registered with the cluster
@@ -21,7 +21,7 @@ import org.apache.log4j.Logger;
  */
 public class Module {
 
-	private static Logger log = Logger.getLogger(Module.class);
+	private static Logger log = LoggerFactory.getLogger(Module.class);
 
 	private String name;
 	protected Map<String, String> values;

--- a/java/src/main/java/com/aerospike/helper/query/KeyRecordIterator.java
+++ b/java/src/main/java/com/aerospike/helper/query/KeyRecordIterator.java
@@ -21,13 +21,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
-
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 import com.aerospike.client.query.KeyRecord;
 import com.aerospike.client.query.RecordSet;
 import com.aerospike.client.query.ResultSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Iterator for traversing a collection of KeyRecords
@@ -40,7 +40,7 @@ public class KeyRecordIterator implements Iterator<KeyRecord>, Closeable {
 	private static final String DIGEST = "digest";
 	private static final String EXPIRY = "expiry";
 	private static final String GENERATION = "generation";
-	private static Logger log = Logger.getLogger(KeyRecordIterator.class);
+	private static Logger log = LoggerFactory.getLogger(KeyRecordIterator.class);
 	private RecordSet recordSet;
 	private ResultSet resultSet;
 	private Iterator<KeyRecord> recordSetIterator;

--- a/java/src/main/java/com/aerospike/helper/query/QueryEngine.java
+++ b/java/src/main/java/com/aerospike/helper/query/QueryEngine.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.log4j.Logger;
-
 import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
@@ -51,6 +49,8 @@ import com.aerospike.client.task.RegisterTask;
 import com.aerospike.helper.model.Index;
 import com.aerospike.helper.model.Module;
 import com.aerospike.helper.model.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class provides a multi-filter query engine that
@@ -65,7 +65,7 @@ public class QueryEngine implements Closeable {
 
 	protected static final String QUERY_MODULE = "as_utility"; //DO NOT use decimal places in the module name
 	protected static final String AS_UTILITY_PATH = QUERY_MODULE + ".lua";
-	protected static Logger log = Logger.getLogger(QueryEngine.class);
+	protected static Logger log = LoggerFactory.getLogger(QueryEngine.class);
 	protected AerospikeClient client;
 	protected Map<String, Index> indexCache;
 	protected Map<String, Module> moduleCache;

--- a/java/src/test/java/com/aerospike/helper/collections/CollectionsLargeList.java
+++ b/java/src/test/java/com/aerospike/helper/collections/CollectionsLargeList.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,6 +25,8 @@ import com.aerospike.client.Value;
 import com.aerospike.client.cdt.ListOperation;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.helper.query.TestQueryEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("deprecation")
 public class CollectionsLargeList {
@@ -35,7 +36,7 @@ public class CollectionsLargeList {
 
 	private AerospikeClient client;
 
-	protected static Logger log = Logger.getLogger(LargeList.class);
+	protected static Logger log = LoggerFactory.getLogger(LargeList.class);
 
 	public CollectionsLargeList ()
 	{

--- a/java/src/test/java/com/aerospike/helper/collections/CollectionsTimeSeries.java
+++ b/java/src/test/java/com/aerospike/helper/collections/CollectionsTimeSeries.java
@@ -3,7 +3,6 @@ package com.aerospike.helper.collections;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
@@ -11,13 +10,15 @@ import org.junit.Test;
 import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.Key;
 import com.aerospike.client.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CollectionsTimeSeries {
 
 	public static final String NAMESPACE = "test";
 	public static final String SET = "time_series";
 
-	protected static Logger log = Logger.getLogger(CollectionsTimeSeries.class);
+	protected static Logger log = LoggerFactory.getLogger(CollectionsTimeSeries.class);
 	private AerospikeClient client;
 
 	//	@Before

--- a/java/src/test/java/com/aerospike/helper/log4j/AerospikeLog4jAppenderIntegrationTests.java
+++ b/java/src/test/java/com/aerospike/helper/log4j/AerospikeLog4jAppenderIntegrationTests.java
@@ -15,10 +15,11 @@
  */
 package com.aerospike.helper.log4j;
 
-import org.apache.log4j.Logger;
-import org.apache.log4j.MDC;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * Integration tests for {@link AerospikeLog4jAppender}.
@@ -29,7 +30,7 @@ public class AerospikeLog4jAppenderIntegrationTests {
 
 	static final String NAME = AerospikeLog4jAppenderIntegrationTests.class.getName();
 
-	Logger log = Logger.getLogger(NAME);
+	Logger log = LoggerFactory.getLogger(NAME);
 	
 
 	@Before


### PR DESCRIPTION
Log4j 1 is already 3 years [EOL](https://blogs.apache.org/foundation/entry/apache_logging_services_project_announces). Replaced logging with slf4j-api.
There is also custom appender based on 1.x API, which I didn't update, cause it doesn't have any tests.
Please consider updating it as well.
Thanks.
