### PR TITLE
Remove jar with dependencies step

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -85,6 +85,7 @@
 			<groupId>com.aerospike</groupId>
 			<artifactId>aerospike-client</artifactId>
 			<version>[4.1.4,)</version>
+			<scope>provided</scope>
 		</dependency>
 		
 		<!-- Apache command line parser. -->
@@ -118,7 +119,7 @@
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.9.3</version>
-			<scope>provided</scope>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>
@@ -128,37 +129,17 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
 				</configuration>
 			</plugin>
 
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-					<finalName>${project.artifactId}-${project.version}</finalName>
-					<appendAssemblyId>false</appendAssemblyId>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-my-jar-with-dependencies</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
 	        <plugin>
 	          <groupId>org.apache.maven.plugins</groupId>
 	          <artifactId>maven-source-plugin</artifactId>
-	          <version>2.2.1</version>
+	          <version>3.0.1</version>
 	          <executions>
 	            <execution>
 	              <id>attach-sources</id>
@@ -172,7 +153,7 @@
 	        <plugin>
 	          <groupId>org.apache.maven.plugins</groupId>
 	          <artifactId>maven-javadoc-plugin</artifactId>
-	          <version>2.9.1</version>
+	          <version>3.0.1</version>
 	          <executions>
 	            <execution>
 	              <id>attach-javadocs</id>


### PR DESCRIPTION
- Remove jar with dependencies step (aerospike-helper should not pack aerospike-client inside jar as it leads to having 2 versions of classes on classpath: one from aerospike-helper, the other one from aerospike-client)
- Update maven plugins

