### PR TITLE
Sets with colons fix from 1.2.3

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,5 +1,43 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### Logs ###
+*.log
+*.log*
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+
+### Eclipse ###
 .classpath
 .project
+.settings/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+### Mac OS ###
 .DS_Store
-/target
-**/.settings
+
+### Vagrant ###
+.vagrant
+ubuntu-*.log
+
+### Ansible ###
+.ansible/*.retry

--- a/java/build.sbt
+++ b/java/build.sbt
@@ -4,7 +4,7 @@ organization := "com.aerospike"
 
 javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8", "-g:lines")
 
-libraryDependencies ++= Seq("com.aerospike" % "aerospike-client" % "3.3.3",
+libraryDependencies ++= Seq("com.aerospike" % "aerospike-client" % "4.2.0",
 	"commons-cli" % "commons-cli" % "1.3.1",
 	"log4j" % "log4j" % "1.2.17",
 	"joda-time" % "joda-time" % "2.9.4",

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.aerospike</groupId>
 	<artifactId>aerospike-helper-java</artifactId>
-	<version>1.2.3</version>
+	<version>1.2.4</version>
 	<name>aerospike-helper-java</name>
 	<organization>
 		<name>Aerospike Inc.</name>
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>com.aerospike</groupId>
 			<artifactId>aerospike-client</artifactId>
-			<version>[4.1.4,)</version>
+			<version>4.2.0</version>
 		</dependency>
 		
 		<!-- Apache command line parser. -->

--- a/java/src/main/java/com/aerospike/helper/model/Set.java
+++ b/java/src/main/java/com/aerospike/helper/model/Set.java
@@ -62,7 +62,7 @@ public class Set {
         if (!info.isEmpty()) {
             String[] parts = splitWithFix(info);
             if (values == null) {
-                values = new HashMap<String, NameValuePair>();
+                values = new HashMap<>();
             }
 
             for (String part : parts) {
@@ -88,26 +88,30 @@ public class Set {
     public void mergeSetInfo(String info) {
 	//ns=test:set=selector:objects=1000:memory_data_bytes=0:deleting=false:stop-writes-count=0:set-enable-xdr=use-default:disable-eviction=false
         if (!info.isEmpty()) {
-            String[] parts = info.split(":");
+            String[] parts = splitWithFix(info);
             if (values == null) {
-                values = new HashMap<String, NameValuePair>();
+                values = new HashMap<>();
             }
 
             for (String part : parts) {
                 String[] kv = part.split("=");
                 String key = kv[0];
-                String value = kv[1];
-                NameValuePair storedValue = values.get(key);
-                if (storedValue == null) {
-                    storedValue = new NameValuePair(this, key, value);
-                    values.put(key, storedValue);
-                } else {
-                    try {
-                        Long newValue = Long.parseLong(value);
-                        Long oldValue = Long.parseLong(storedValue.value.toString());
-                        storedValue.value = Long.toString(oldValue + newValue);
-                    } catch (NumberFormatException e) {
-                        storedValue.value = value;
+
+                // lenght should always be 2 - fix should prevent errors
+                if (kv.length == 2) {
+                    String value = kv[1];
+                    NameValuePair storedValue = values.get(key);
+                    if (storedValue == null) {
+                        storedValue = new NameValuePair(this, key, value);
+                        values.put(key, storedValue);
+                    } else {
+                        try {
+                            Long newValue = Long.parseLong(value);
+                            Long oldValue = Long.parseLong(storedValue.value.toString());
+                            storedValue.value = Long.toString(oldValue + newValue);
+                        } catch (NumberFormatException e) {
+                            storedValue.value = value;
+                        }
                     }
                 }
             }
@@ -142,7 +146,10 @@ public class Set {
     }
 
     /**
-     * Fix to allow having sets that include ":" characters.
+     * Fix to allow having sets that include ":" characters. <p>
+     *
+     * </p>Related to aerospike bug that allows creating sets with colons. If aerospike contains AT LEAST ONE set like that,
+     * using this library without the fix would make throw an IndexOutOfBoundsException.
      */
     private String[] splitWithFix(final String sets) {
         final LinkedList<String> keyValuesSplitFix = new LinkedList<>();

--- a/java/src/test/java/com/aerospike/helper/model/SetTest.java
+++ b/java/src/test/java/com/aerospike/helper/model/SetTest.java
@@ -1,0 +1,26 @@
+package com.aerospike.helper.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SetTest {
+
+    @Test
+    public void testSetInfo() {
+
+        String sets = "a=b:c=d:set_name=f:bugged:g=h";
+
+        Set underTest = new Set(null, sets);
+
+        assertEquals("f:bugged", underTest.getName());
+        assertEquals(4, underTest.values.size());
+
+        assertEquals("b", underTest.values.get("a").value);
+        assertEquals("f:bugged", underTest.values.get("set_name").value);
+        assertEquals("d", underTest.values.get("c").value);
+        assertEquals("h", underTest.values.get("g").value);
+
+    }
+
+}

--- a/java/src/test/java/com/aerospike/helper/model/SetTest.java
+++ b/java/src/test/java/com/aerospike/helper/model/SetTest.java
@@ -9,15 +9,32 @@ public class SetTest {
     @Test
     public void testSetInfo() {
 
+        String sets = "a=b:c=d:set_name=f:g=h";
+
+        Set underTest = new Set(null, sets);
+
+        assertEquals("f", underTest.getName());
+        assertEquals(4, underTest.values.size());
+
+        assertEquals("b", underTest.values.get("a").value);
+        assertEquals("f", underTest.values.get("set_name").value);
+        assertEquals("d", underTest.values.get("c").value);
+        assertEquals("h", underTest.values.get("g").value);
+
+    }
+
+    @Test
+    public void testSetInfoWhenSetNameContainsColons() {
+
         String sets = "a=b:c=d:set_name=f:bugged:g=h";
 
         Set underTest = new Set(null, sets);
 
-        assertEquals("f:bugged", underTest.getName());
+        assertEquals("f", underTest.getName());
         assertEquals(4, underTest.values.size());
 
         assertEquals("b", underTest.values.get("a").value);
-        assertEquals("f:bugged", underTest.values.get("set_name").value);
+        assertEquals("f", underTest.values.get("set_name").value);
         assertEquals("d", underTest.values.get("c").value);
         assertEquals("h", underTest.values.get("g").value);
 


### PR DESCRIPTION
Fix to prevent an IndexOutOfBoundsException when trying to connect to an Aerospike server that has at least one set that contains colons.

It is related to two Aerospike bugs:

1. It allows creating sets with colons (:), although documentation mentions that is an illegal character.
2. When using asinfo command (same command used by this library), it would return a string containing key values using ":" as separator. It would also show set name fragments when using aql on select queries. Example: "ns_name=test:set_name=bad:name:n_objects=1:set-stop-write-count=0"

Then, library won't notice if colon is part of the set name, creating a key without a value. From the example above, "name" would be intepreted as a key without a value, raising an IndexOutOfBoundsException.

The solution involves fixing the parse process of this string. For that, it can be traversed as follows in order to get the correct key value pairs:

1. Start from the end of the string
2. Find the first "=" character. Traversed string contains a value.
3. Find the first ":". Traversed string contains the key to value got in 2.
4. Go to step 2 if there are more characters. 

